### PR TITLE
Fixed bug caused by our failure to check if the '=' was found immedia…

### DIFF
--- a/Server/Source/http-s_req.c
+++ b/Server/Source/http-s_req.c
@@ -1644,12 +1644,17 @@ static  void  HTTPsReq_HdrParse (HTTPs_INSTANCE  *p_instance,
                                                                     sizeof(HTTP_STR_MULTIPART_BOUNDARY));
 
                                           if (p_val == DEF_NULL) {
-                                              *p_err = HTTPs_ERR_REQ_FORMAT_INVALID;
-                                               return;
+                                             *p_err = HTTPs_ERR_REQ_FORMAT_INVALID;
+                                              return;
                                           }
 
                                                                 /* Boundary located after '='.                          */
                                           p_val = Str_Char_N(p_val, len, ASCII_CHAR_EQUALS_SIGN);
+                                          if (p_val == DEF_NULL) {
+                                             *p_err = HTTPs_ERR_REQ_FORMAT_INVALID;
+                                              return;
+                                          }
+
                                           p_val++;              /* Remove space before boundary val.                    */
                                           p_val = HTTP_StrGraphSrchFirst(p_val,
                                                                          len);
@@ -1676,8 +1681,8 @@ static  void  HTTPsReq_HdrParse (HTTPs_INSTANCE  *p_instance,
                                  }
                              }
 
-                         } else {                               /* Should not occurs.                                   */
-                            *p_err   = HTTPs_ERR_REQ_MORE_DATA_REQUIRED;
+                         } else {                               /* Should not occur.                                    */
+                            *p_err = HTTPs_ERR_REQ_MORE_DATA_REQUIRED;
                              return;
                          }
                          break;


### PR DESCRIPTION
…tely following the 'boundary' parameter in a multipart request. Cisco/Talos reproduced this bug by simply sending the server a malformed request without everything that would normally su